### PR TITLE
Fix typos in documentation and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you're experiencing search/preview issues, try clearing out your mod data dir
 * Hunt event buttons: random hunt event (show roll), forest gate, overwhelming darkness, sky fishing, herb gathering, mineral gathering.
 * Monster-specific quotes.
 * Lock terrain after setting up showdown.
-* Fixed Binge eating hagve misspelling.
+* Fixed Binge eating have misspelling.
 * Add reroll token and a slot on the token board.
 * Constellation and import/export boards have slightly different colors than the rest of the boards.
 * Rescan all gear.

--- a/Survivor.ttslua
+++ b/Survivor.ttslua
@@ -167,7 +167,7 @@ function Survivor.InitSaveState(saveState)
     for _, survivorBoxSaveState in ipairs(saveState.survivorBoxes or {}) do
         local survivor = Survivor.survivorsById[survivorBoxSaveState.survivorId]
         if not survivor then
-            return log:Errorf("Survivor box %s was saved with non-existant survivor %d", survivorBoxSaveState.objectGuid, survivorBoxSaveState.survivorId)
+            return log:Errorf("Survivor box %s was saved with non-existent survivor %d", survivorBoxSaveState.objectGuid, survivorBoxSaveState.survivorId)
         end
 
         local object = getObjectFromGUID(survivorBoxSaveState.objectGuid)
@@ -185,7 +185,7 @@ function Survivor.InitSaveState(saveState)
     for _, survivorSheetSaveState in ipairs(saveState.survivorSheets or {}) do
         local survivor = Survivor.survivorsById[survivorSheetSaveState.survivorId]
         if not survivor then
-            return log:Errorf("Survivor sheet %s was saved with non-existant survivor %d", survivorSheetSaveState.survivorSheetGuid, survivorSheetSaveState.survivorId)
+            return log:Errorf("Survivor sheet %s was saved with non-existent survivor %d", survivorSheetSaveState.survivorSheetGuid, survivorSheetSaveState.survivorId)
         end
 
         local object = getObjectFromGUID(survivorSheetSaveState.objectGuid)


### PR DESCRIPTION
## Summary
- fix typo in README 'hagve'
- correct 'non-existant' spelling in Survivor error messages

## Testing
- `bash -n restoreBackup.sh`
- `bash -n updateTTS.sh`


------
https://chatgpt.com/codex/tasks/task_e_683c52267078832fbde4712d2385263f