### PR TITLE
fix: make session-closing protocol work in remote sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "say -v Anna Zustimmung erfordert"
+            "command": "command -v say >/dev/null 2>&1 && say -v Anna Zustimmung erfordert || true"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "says -v Anna Reaktion erfordert"
+            "command": "command -v say >/dev/null 2>&1 && say -v Anna Reaktion erfordert || true"
           }
         ]
       }
@@ -28,11 +28,11 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "You are validating whether the session-closing protocol was followed. Check the transcript for these requirements:\n\n1. **Git status check**: Was `git status` actually executed (not just mentioned)?\n2. **Bead check**: Was `bd list --status=closed` executed to check for recently closed beads?\n3. **Learning capture**: Was the Edit tool used to append content to `handover/LEARNINGS.md`? (Terminal output doesn't count)\n4. **Closing signature**: Is there a closing signature block with ═══════════════════════════════════════ and ROLE END?\n5. **Voice announcement**: Was a `say -v` command executed with a German message?\n\nIMPORTANT EXCEPTIONS - Allow session to end WITHOUT these checks if:\n- This is a research/exploration session (no code changes made)\n- User explicitly said to skip closing protocol\n- Session is just starting (minimal transcript)\n- User is asking a quick question\n\nIf requirements are missing AND this appears to be a substantive work session, respond with:\n- decision: block\n- reason: List what's missing and remind to invoke the session-closing skill\n\nIf requirements are met OR this is a lightweight session, respond with:\n- decision: approve"
+            "prompt": "You are validating whether the session-closing protocol was followed. Check the transcript for these requirements:\n\n1. **Git status check**: Was `git status` actually executed (not just mentioned)?\n2. **Bead check**: Was `bd list --status=closed` executed to check for recently closed beads? (SKIP if `bd` command not available - remote sessions don't have beads installed)\n3. **Learning capture**: Was the Edit tool used to append content to `handover/LEARNINGS.md`? (Terminal output doesn't count)\n4. **Closing signature**: Is there a closing signature block with ═══════════════════════════════════════ and ROLE END?\n5. **Voice announcement**: Was a `say -v` command executed OR was the voice announcement explicitly skipped because `say` is not available (remote session)?\n\nREMOTE SESSION DETECTION:\n- If transcript shows commands failing with 'command not found' for `say` or `bd`, this is a remote session\n- Remote sessions may skip voice announcements and bead checks\n- Git status and learning capture are still required\n- Closing signature is still required\n\nIMPORTANT EXCEPTIONS - Allow session to end WITHOUT these checks if:\n- This is a research/exploration session (no code changes made)\n- User explicitly said to skip closing protocol\n- Session is just starting (minimal transcript)\n- User is asking a quick question\n\nIf requirements are missing AND this appears to be a substantive work session, respond with:\n- decision: block\n- reason: List what's missing and remind to invoke the session-closing skill\n\nIf requirements are met OR this is a lightweight session, respond with:\n- decision: approve"
           },
           {
             "type": "command",
-            "command": "say -v Anna Fertig"
+            "command": "command -v say >/dev/null 2>&1 && say -v Anna Fertig || echo '[Voice] Session beendet'"
           }
         ]
       }


### PR DESCRIPTION
Add fallbacks for macOS-specific commands (say) and local-only tools (bd)
that are not available in remote environments like GitHub Codespaces or
Claude Code Web.

Changes:
- settings.json: Wrap say commands with availability checks, update Stop
  hook prompt to recognize remote sessions
- session-closing skill: Add Remote Session Handling section, document
  fallback behavior, update self-check items with remote session notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>