### PR TITLE
fix: move examples outside YAML frontmatter in kdm-solid-reviewer

### DIFF
--- a/.claude/agents/acceptance-test-writer.md
+++ b/.claude/agents/acceptance-test-writer.md
@@ -1,6 +1,9 @@
 ---
 name: acceptance-test-writer
 description: Write headless acceptance tests that verify user-visible behavior using domain language. Use after implementation is complete and code-reviewer approved, before TTS tests. Triggers on acceptance test, user-visible behavior, TestWorld, feature verification, ACCEPTANCE prefix, headless test for feature.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: sonnet
+---
 
 <example>
 Context: Implementer finished feature, code-reviewer approved, needs acceptance tests
@@ -28,11 +31,6 @@ assistant: "I'll use the acceptance-test-writer agent to create documentation-qu
 Tests as documentation: someone reading tests should understand the feature.
 </commentary>
 </example>
-
-tools: Read, Write, Edit, Grep, Glob, Bash
-model: sonnet
----
-
 You are an acceptance test specialist who writes tests from the user's perspective using domain language. Your tests serve as executable documentation of feature behavior.
 
 ## Core Philosophy

--- a/.claude/agents/beads-backlog-manager.md
+++ b/.claude/agents/beads-backlog-manager.md
@@ -1,6 +1,9 @@
 ---
 name: beads-backlog-manager
 description: Use this agent when the user needs to interact with the beads (`bd`) issue tracking system. Use PROACTIVELY when users mention potential features, tasks, or bugs that should be tracked. This includes: looking up existing backlog items, organizing or categorizing beads, discovering new items that should be tracked, updating bead metadata or status, querying the backlog, or getting an overview of current work items.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
 
 <example>
 Context: User wants to see what's in the backlog
@@ -55,10 +58,6 @@ assistant: "Let me use the beads-backlog-manager agent to filter beads by type a
 Filtered query. Use bd list with appropriate flags.
 </commentary>
 </example>
-tools: Read, Grep, Glob, Bash
-model: haiku
----
-
 You are an expert backlog analyst and issue tracking specialist with deep knowledge of the beads (`bd`) workflow system. Your role is to maintain a clear, organized view of all work items and help users navigate their backlog efficiently.
 
 ## First Steps

--- a/.claude/agents/characterization-test-writer.md
+++ b/.claude/agents/characterization-test-writer.md
@@ -1,6 +1,9 @@
 ---
 name: characterization-test-writer
 description: Write characterization tests before modifying untested or legacy code. Use PROACTIVELY when Implementer plans to modify code that lacks tests, when refactoring requires safety net, or when existing behavior must be preserved. Triggers on legacy code, untested code, characterization test, before refactoring, capture existing behavior, Feathers patterns.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
 
 <example>
 Context: Implementer needs to modify a function that has no tests
@@ -28,11 +31,6 @@ assistant: "I'll use the characterization-test-writer agent to document the exis
 Discovery use: tests as documentation for understanding existing code.
 </commentary>
 </example>
-
-tools: Read, Grep, Glob, Bash
-model: sonnet
----
-
 You are a characterization test specialist applying Michael Feathers' techniques from "Working Effectively with Legacy Code". You write tests that capture existing behavior before modifications, creating a safety net for refactoring.
 
 ## Core Philosophy

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,9 @@
 ---
 name: code-reviewer
 description: Expert code reviewer with configurable depth. Use PROACTIVELY when implementation work reaches completion. Supports three depth presets (quick/standard/comprehensive) that determine whether perspective reviewers are invoked. Returns structured feedback for same-session fix loops until APPROVED. Significant findings go to LEARNINGS.md for audit trail.
+tools: Glob, Grep, Read, Bash, Task
+model: opus
+---
 
 <example>
 Context: Implementer has finished coding a feature
@@ -56,9 +59,6 @@ assistant: "Fixes applied. Let me re-invoke code-reviewer to verify."
 Same-session fix loop. Fix issues immediately, re-invoke until APPROVED.
 </commentary>
 </example>
-tools: Glob, Grep, Read, Bash, Task
-model: opus
----
 
 You are the Code Reviewer for the KDM TTS mod, operating within an agile role-based workflow. Your review ensures quality gates are met before work flows to the next role.
 

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,6 +1,9 @@
 ---
 name: debugger
 description: Use this agent for quick diagnostic analysis without switching to full Debugger role. **MUST USE after 2 failed attempts** at fixing the same issue. Use PROACTIVELY when Implementer encounters errors, unexpected behavior, UI not showing, objects not spawning, or any "it should work but doesn't" situation. Triggers on error, nil value, not showing, not working, doesn't work, failed attempt, still broken, same issue.
+tools: Glob, Grep, Read, Bash
+model: sonnet
+---
 
 <example>
 Context: Tester found a bug but is unsure of root cause
@@ -63,10 +66,6 @@ assistant: "Let me use the debugger agent to trace the coordinate flow and find 
 No error message but wrong result. Trace execution to find issue.
 </commentary>
 </example>
-tools: Glob, Grep, Read, Bash
-model: sonnet
----
-
 You are the Debugger diagnostic assistant for the KDM TTS mod. You help Tester and Implementer roles diagnose bugs without requiring a full Debugger role handover.
 
 ## First Steps

--- a/.claude/agents/handover-manager.md
+++ b/.claude/agents/handover-manager.md
@@ -1,6 +1,10 @@
 ---
 name: handover-manager
 description: Manages handover files and queue for role-based workflow. MUST BE USED when (1) work is complete and ready for next role, (2) session starts and needs pending handover check, (3) session ends and queue needs cleanup. **Cleanup removes COMPLETED/SUPERSEDED queue entries AND deletes orphaned HANDOVER_*.md files from disk.** Triggers on phrases like 'done', 'finished', 'ready for', 'hand off to', 'pass to', 'cleanup', session start, session end.
+tools: Glob, Grep, Read, Edit, Write, Bash
+model: haiku
+permissionMode: acceptEdits
+---
 
 <example>
 Context: Implementer says work is done
@@ -55,11 +59,6 @@ assistant: "Let me use the handover-manager agent to mark that handover as ACKNO
 Reading handover triggers status update.
 </commentary>
 </example>
-tools: Glob, Grep, Read, Edit, Write, Bash
-model: haiku
-permissionMode: acceptEdits
----
-
 You are a handover management specialist for the KDM TTS mod's role-based workflow. You handle the mechanical aspects of handover file creation, queue management, and cleanup.
 
 ## First Steps

--- a/.claude/agents/handover-writer.md
+++ b/.claude/agents/handover-writer.md
@@ -1,6 +1,9 @@
 ---
 name: handover-writer
 description: Use this agent to compose well-structured, complete handover content. Use PROACTIVELY when creating handovers to ensure all required information is included. MUST BE USED when unsure what to include in a handover or when handover quality matters for complex tasks.
+tools: Read, Glob, Grep
+model: haiku
+---
 
 <example>
 Context: Architect needs to create handover to Implementer
@@ -55,10 +58,6 @@ assistant: "Let me use the handover-writer agent to structure the diagnosis with
 Debug findings handover. Handover-writer ensures clear diagnosis documentation for implementation.
 </commentary>
 </example>
-tools: Read, Glob, Grep
-model: haiku
----
-
 You are a handover content specialist for the KDM TTS mod's role-based workflow. You help roles create high-quality, complete handover documents that enable smooth collaboration between roles.
 
 ## First Steps

--- a/.claude/agents/kdm-solid-reviewer.md
+++ b/.claude/agents/kdm-solid-reviewer.md
@@ -1,6 +1,9 @@
 ---
 name: kdm-solid-reviewer
 description: KDM-specific SOLID and testability reviewer. Detects type-based dispatch (OCP violations), direct TTS API calls, and untestable patterns documented in docs/SOLID_ANALYSIS.md. MANDATORY for all code reviews. Returns BLOCKING when violations found in changed code.
+tools: Glob, Grep, Read
+model: haiku
+---
 
 <example>
 Context: New code adds type-based dispatch
@@ -17,10 +20,6 @@ assistant: "[KDM-SOLID] BLOCKING: Direct Wait.frames call - use TTSAdapter"
 Testability anti-pattern. TTSAdapter exists for this purpose.
 </commentary>
 </example>
-
-tools: Glob, Grep, Read
-model: haiku
----
 
 You are a specialized SOLID reviewer for the KDM TTS mod. Your job is to detect violations documented in `docs/SOLID_ANALYSIS.md` and block reviews when changed code sections contain these anti-patterns.
 

--- a/.claude/agents/maintainability-reviewer.md
+++ b/.claude/agents/maintainability-reviewer.md
@@ -1,6 +1,9 @@
 ---
 name: maintainability-reviewer
 description: Maintainability-focused code review perspective. Examines code for SOLID violations, coupling, complexity, and technical debt. Use when adding new modules, refactoring, or when changes touch multiple files.
+tools: Glob, Grep, Read
+model: sonnet
+---
 
 <example>
 Context: New module being added
@@ -19,11 +22,6 @@ assistant: "Let me use the maintainability-reviewer agent to verify the abstract
 Refactoring should improve, not complicate. Check the new structure is maintainable.
 </commentary>
 </example>
-
-tools: Glob, Grep, Read
-model: sonnet
----
-
 You are a Maintainability Reviewer for the KDM TTS mod. Your focus is ensuring code remains easy to understand, modify, and extend.
 
 ## First Steps

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -1,6 +1,9 @@
 ---
 name: performance-reviewer
 description: Performance-focused code review perspective. Examines code for inefficient loops, memory issues, TTS API overhead, and scaling problems. Use when changes involve iteration, spawning, deck operations, or UI rendering.
+tools: Glob, Grep, Read
+model: sonnet
+---
 
 <example>
 Context: Code iterating over game objects
@@ -19,11 +22,6 @@ assistant: "Let me use the performance-reviewer agent to verify spawning is batc
 Archive.Take is async and slow. Check for unnecessary sequential spawns.
 </commentary>
 </example>
-
-tools: Glob, Grep, Read
-model: sonnet
----
-
 You are a Performance Reviewer for the KDM TTS mod. Your focus is identifying inefficiencies that could cause lag, slow loading, or poor user experience.
 
 ## TTS Performance Context

--- a/.claude/agents/refactoring-advisor.md
+++ b/.claude/agents/refactoring-advisor.md
@@ -1,6 +1,9 @@
 ---
 name: refactoring-advisor
 description: Analyzes code for refactoring opportunities per SOLID principles and CODE_REVIEW_GUIDELINES. **MUST USE** after code-reviewer finds ANY code smell (DRY violation, SRP violation, large file, duplication). Also use proactively when Architect designs changes to files >300 lines. Triggers on: DRY violation, code smell, duplication, file size, SOLID, SRP violation, large module, copy-paste, similar code, refactoring, hard to maintain.
+tools: Glob, Grep, Read
+model: sonnet
+---
 
 <example>
 Context: code-reviewer found DRY violation
@@ -54,10 +57,6 @@ assistant: "Let me use the refactoring-advisor agent to identify structural issu
 Repeated bugs suggest design problems. Refactoring analysis identifies root causes.
 </commentary>
 </example>
-tools: Glob, Grep, Read
-model: sonnet
----
-
 You are a refactoring advisor for the KDM TTS mod. You analyze Lua modules for SOLID principle violations and code smells, then recommend specific refactoring strategies prioritized by impact, effort, and risk.
 
 ## First Steps

--- a/.claude/agents/screenshot-analyzer.md
+++ b/.claude/agents/screenshot-analyzer.md
@@ -1,6 +1,9 @@
 ---
 name: screenshot-analyzer
 description: Use this agent when the user wants to analyze, describe, or extract information from screenshots on their Desktop. Use PROACTIVELY when user mentions taking a screenshot, says "I see" followed by visual descriptions, or says "see screenshot". This includes requests to see what's in a screenshot, identify UI elements, read text from images, understand visual content, or compare multiple screenshots.
+tools: Read, Bash
+model: sonnet
+---
 
 <example>
 Context: User wants to know what's in their latest screenshot without specifying a file.
@@ -46,10 +49,6 @@ assistant: "I'll use the screenshot-analyzer agent to find and compare your two 
 Comparison request. Agent finds multiple files and identifies differences.
 </commentary>
 </example>
-tools: Read, Bash
-model: sonnet
----
-
 You are an expert screenshot analyst with deep expertise in image processing, UI/UX interpretation, and visual content extraction. You specialize in analyzing macOS screenshots with automatic file discovery and size optimization.
 
 ## First Steps

--- a/.claude/agents/seam-finder.md
+++ b/.claude/agents/seam-finder.md
@@ -1,6 +1,9 @@
 ---
 name: seam-finder
 description: Analyzes Lua modules to identify specific testability seams (injection points) for breaking dependencies. Use PROACTIVELY when Architect is planning test strategy for existing code, before adding tests to legacy modules, or when modules are hard to test. Returns actionable refactoring recommendations using project patterns.
+tools: Read, Grep, Glob
+model: sonnet
+---
 
 <example>
 Context: Architect planning test strategy
@@ -55,10 +58,6 @@ assistant: "Let me use the seam-finder agent to identify the easiest seams to ad
 Need test coverage for reliability. Agent prioritizes seams by impact.
 </commentary>
 </example>
-tools: Read, Grep, Glob
-model: sonnet
----
-
 You are a testability analyzer for the KDM TTS mod. You identify specific dependency seams in Lua modules and recommend concrete refactoring patterns using established project conventions.
 
 ## First Steps

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,6 +1,9 @@
 ---
 name: security-reviewer
 description: Security-focused code review perspective. Examines code for injection vulnerabilities, input validation gaps, secrets exposure, and unsafe patterns. Use when changes handle external input, file paths, user-provided data, or sensitive operations.
+tools: Glob, Grep, Read
+model: sonnet
+---
 
 <example>
 Context: Code handling user input from TTS UI
@@ -19,11 +22,6 @@ assistant: "Let me use the security-reviewer agent to verify path handling is sa
 File operations need path validation to prevent directory traversal.
 </commentary>
 </example>
-
-tools: Glob, Grep, Read
-model: sonnet
----
-
 You are a Security Reviewer for the KDM TTS mod. Your focus is identifying security vulnerabilities and unsafe patterns, even in a local mod context.
 
 ## Security Focus Areas

--- a/.claude/agents/skill-manager.md
+++ b/.claude/agents/skill-manager.md
@@ -1,6 +1,10 @@
 ---
 name: skill-manager
 description: Use this agent to create, modify, or optimize Claude Code skills. Skills are model-invoked capabilities that Claude automatically uses based on context. Use PROACTIVELY when users mention recurring workflows, domain expertise needs, or want to extend Claude's capabilities.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+permissionMode: acceptEdits
+---
 
 <example>
 Context: User wants a new specialized skill
@@ -55,11 +59,6 @@ assistant: "Let me use the skill-manager agent to inventory and describe all ava
 Inventory request. Skill-manager will scan both personal and project skill directories.
 </commentary>
 </example>
-tools: Read, Write, Edit, Glob, Grep, Bash
-model: sonnet
-permissionMode: acceptEdits
----
-
 You are an expert in designing, creating, and optimizing Claude Code skills. You understand the skill architecture deeply — particularly the three-level progressive disclosure system and the critical importance of well-crafted descriptions for automatic invocation.
 
 **You have FULL WRITE ACCESS to skill files.** Apply changes directly without asking for permission.

--- a/.claude/agents/subagent-creator.md
+++ b/.claude/agents/subagent-creator.md
@@ -1,6 +1,10 @@
 ---
 name: subagent-creator
 description: Use this agent to create, modify, or optimize custom subagents. MUST BE USED when (1) user mentions repetitive manual work that could be automated, (2) an agent isn't triggering or working correctly, (3) user wants new specialized capability. Triggers on phrases like 'keep having to', 'always manually', 'never triggers', 'agent doesn't', 'should automatically', 'too slow', 'too verbose', 'need an agent for'.
+tools: Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
+model: sonnet
+permissionMode: acceptEdits
+---
 
 <example>
 Context: User describes repetitive manual task
@@ -46,10 +50,6 @@ assistant: "I'll use the subagent-creator to design and create a database migrat
 Explicit "create an agent" request.
 </commentary>
 </example>
-tools: Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
-model: sonnet
-permissionMode: acceptEdits
----
 
 You are an expert in designing, creating, and optimizing Claude Code subagents. You understand the subagent architecture deeply and help create new agents, enhance existing ones, and troubleshoot agent issues.
 
@@ -102,20 +102,28 @@ Every agent file uses this structure:
 ```yaml
 ---
 name: kebab-case-name
-description: Clear description with examples showing when to use
+description: When Claude should delegate to this agent
 tools: Tool1, Tool2, Tool3
 model: sonnet|opus|haiku
 ---
 
+<example>
+Context: [situation]
+user: "[message]"
+assistant: "[response]"
+</example>
+
 [System prompt body]
 ```
+
+**Important:** Examples go in the markdown body AFTER the closing `---`, not inside the YAML frontmatter. GitHub's YAML parser rejects examples inside frontmatter.
 
 ### Required Frontmatter Fields
 
 | Field | Format | Purpose |
 |-------|--------|---------|
 | `name` | kebab-case | Unique identifier |
-| `description` | Natural language + examples | When/how Claude invokes this agent |
+| `description` | Simple string | When/how Claude invokes this agent |
 
 ### Optional Frontmatter Fields
 
@@ -138,10 +146,20 @@ model: sonnet|opus|haiku
 
 ## Description Field Best Practices
 
-The description is CRITICAL — it determines automatic invocation. Follow this pattern:
+The description determines automatic invocation. Keep it as a simple string in the frontmatter:
 
-```
+```yaml
 description: [One sentence purpose]. Use PROACTIVELY when [trigger conditions].
+```
+
+**Examples go in the body** (after closing `---`), not in the frontmatter:
+
+```markdown
+---
+name: my-agent
+description: Purpose. Use PROACTIVELY when [conditions].
+tools: Read, Grep
+---
 
 <example>
 Context: [Situation]
@@ -151,6 +169,8 @@ assistant: "[How assistant invokes agent]"
 [Why this triggers the agent]
 </commentary>
 </example>
+
+You are [role]...
 ```
 
 **Include 4-6 examples covering:**
@@ -160,10 +180,10 @@ assistant: "[How assistant invokes agent]"
 - Modification/optimization requests
 - Edge cases or variations
 
-**Required proactive phrases:**
+**Required proactive phrases in description:**
 - "Use PROACTIVELY when..."
 - "MUST BE USED before/after..."
-- Include commentary explaining WHY each example triggers
+- Include commentary in examples explaining WHY each triggers
 
 ## System Prompt Structure
 

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,6 +1,9 @@
 ---
 name: test-runner
 description: Use this agent to run headless Lua tests and analyze results. Use PROACTIVELY after code changes before handovers, when tests fail unexpectedly, to verify test coverage, or for quick test verification during implementation. This agent executes tests, parses output, identifies failures, and suggests fixes based on error patterns.
+tools: Bash, Read, Grep
+model: haiku
+---
 
 <example>
 Context: Implementer finished code changes and needs to verify tests pass
@@ -55,10 +58,6 @@ assistant: "Let me use the test-runner agent to run those tests and analyze what
 Regression investigation: identify what broke and why.
 </commentary>
 </example>
-tools: Bash, Read, Grep
-model: haiku
----
-
 You are a test execution and analysis specialist for the KDM TTS mod. You run headless Lua tests via `lua tests/run.lua`, parse results, identify failures, and provide actionable diagnostic feedback.
 
 ## First Steps

--- a/.claude/agents/tts-test-writer.md
+++ b/.claude/agents/tts-test-writer.md
@@ -1,6 +1,9 @@
 ---
 name: tts-test-writer
 description: Write automated TTS console tests for behavior that requires in-game verification. Use after acceptance tests when TTS-specific verification is needed (UI, spawning, visual placement, Archive operations). Triggers on TTS test, console test, testall, testfocus, in-game verification, UI test, spawn test.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: sonnet
+---
 
 <example>
 Context: Feature has UI that needs TTS verification
@@ -28,11 +31,6 @@ assistant: "I'll use the tts-test-writer agent to create tests that verify card 
 Physical verification: TTS tests verify actual object positions and states.
 </commentary>
 </example>
-
-tools: Read, Write, Edit, Grep, Glob, Bash
-model: sonnet
----
-
 You are a TTS console test specialist who writes automated tests that run inside Tabletop Simulator via `>testall` and `>testfocus` commands.
 
 ## Core Philosophy

--- a/.claude/agents/ux-advisor.md
+++ b/.claude/agents/ux-advisor.md
@@ -1,6 +1,9 @@
 ---
 name: ux-advisor
 description: UX consultation for usability decisions. **MUST USE proactively** when working on features involving new, expanded, or changed user interaction. Use when designing UI, choosing layouts, evaluating user flows, or deciding interaction patterns. Triggers on new feature, UI change, dialog, button, user flow, interaction pattern, confirmation, notification, feedback mechanism.
+tools: Glob, Grep, Read
+model: sonnet
+---
 
 <example>
 Context: Product Owner starting work on a feature with user interaction
@@ -55,10 +58,6 @@ assistant: "Let me use the ux-advisor agent to map out the user flow and identif
 Flow design question. Advisor thinks through user journey.
 </commentary>
 </example>
-tools: Glob, Grep, Read
-model: sonnet
----
-
 You are a UX advisor for the KDM TTS mod — a Tabletop Simulator implementation of Kingdom Death: Monster. You help Product Owner, Architect, and Implementer make usability decisions.
 
 ## Context


### PR DESCRIPTION
The YAML parser was failing because <example> blocks containing
colons were placed inside the frontmatter. Moved tools: and model:
fields immediately after description:, then closed the frontmatter
before the example blocks.